### PR TITLE
Add server-side init call

### DIFF
--- a/lua/cfc_notifications/shared/sh_base.lua
+++ b/lua/cfc_notifications/shared/sh_base.lua
@@ -32,6 +32,11 @@ if SERVER then
     hook.Add( "PlayerDisconnected", "CFC_NotificationUnready", function( ply )
         CFCNotifications.playersReady[ply] = true
     end )
+
+    -- Give chance for other addons to load
+    timer.Simple( 0, function()
+        hook.Run( "CFC_Notifications_init" )
+    end )
 else
     include( "cfc_notifications/client/cl_net.lua" )
     include( "cfc_notifications/client/cl_dnotification.lua" )


### PR DESCRIPTION
`CFC_Notifications_init` was treated as if it was shared, turned out to only be called client-side. This fixes that.

Delayed with a timer.Simple(0) to allow all addons to load first