### PR TITLE
Allow buttons to be unclickable and/or not auto-close the notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ Below are the predefined notification types (you can define your own) with whate
   - `notification:EditButtonAlignment( buttonRow, buttonColumn, alignment, plys )`
     Edits the alignment of a button.
   - `notification:EditButtonLocation( buttonRow, buttonColumn, newButtonRow, newButtonColumn, plys )`
-    Edits the location of a button. If `notification` has already been sent, this cannot add new button rows, and will not clear out empty rows.  
+    Edits the location of a button. If `notification` has already been sent, this cannot add new button rows, and will not clear out empty rows.
+  - `notification:EditButtonAutoClose( buttonRow, buttonColumn, autoClose, plys )`
+    Edits whether or not a button being pressed will automatically close `notification`. This is `true` by default.
+  - `notification:EditButtonCanPress( buttonRow, buttonColumn, canPress, plys )`
+    Edits whether or not a button can be pressed. This is `true` by default. 
   - Hooks:
     - `notification:OnButtonPressed( data )`
       - Called when a button is pressed with the data used to create it.

--- a/lua/cfc_notifications/client/cl_dnotificationbutton.lua
+++ b/lua/cfc_notifications/client/cl_dnotificationbutton.lua
@@ -17,6 +17,8 @@ function PANEL:Init()
     self.clickAnimState = 0
     self.text = ""
     self.alignment = CFCNotifications.ALIGN_CENTER
+    self.autoClose = true
+    self.canPress = true
     self:SetTextColor( Color( 255, 255, 255 ) )
     self:SetBackgroundColor( Color( 100, 100, 100 ) )
     self.BaseClass.SetText( self, "" ) -- Hide the default panel text since we track and draw the text ourselves
@@ -25,11 +27,18 @@ end
 function PANEL:Think()
     local disabled = self:GetDisabled()
     local textColor = self.textColor
+    local canPress = self.canPress
+
     if disabled then
         self:SetCursor( "no" )
         self.BaseClass.SetTextColor( self, Color( 100, 100, 100 ) )
     else
-        self:SetCursor( "hand" )
+        if canPress then
+            self:SetCursor( "hand" )
+        else
+            self:SetCursor( "no" )
+        end
+
         self.BaseClass.SetTextColor( self, textColor )
     end
 
@@ -39,7 +48,8 @@ function PANEL:Think()
     local change = time - self.lastT
     self.lastT = time
     if change > 1 then change = 0 end -- If there has been > 1 second since last think, dont do the animation
-    if hovered or self.clicked then
+
+    if canPress and ( hovered or self.clicked ) then
         self.animState = math.Clamp( self.animState + change / animSpeed, 0, 1 )
     else
         self.animState = math.Clamp( self.animState - change / animSpeed, 0, 1 )
@@ -86,6 +96,14 @@ function PANEL:SetAlignment( alignment )
     self.alignment = alignment
 end
 
+function PANEL:SetAutoClose( autoClose )
+    self.autoClose = autoClose
+end
+
+function PANEL:SetCanPress( canPress )
+    self.canPress = canPress
+end
+
 function PANEL:Paint( w, h )
     if self:GetDisabled() then return end
 
@@ -93,7 +111,7 @@ function PANEL:Paint( w, h )
     local barHeight = h - uWeight - 4
     local halfWidth = w / 2
 
-    if self.clicked then
+    if self.clicked and self.canPress then
         -- Click animation
         local col = table.Copy( self.textColor )
         col.a = col.a * 0.1
@@ -187,6 +205,8 @@ function PANEL:GetClickAnimationLength()
 end
 
 function PANEL:DoClickInternal()
+    if not self.canPress then return end
+
     self.clicked = true
 end
 


### PR DESCRIPTION
This adds two new attributes to notification buttons, canPress and autoClose, which define whether or not a button can be pressed and whether or not pressing it will automatically close the notification it is a part of.